### PR TITLE
feat: provisioning of IamServiceaccount credentials

### DIFF
--- a/charts/galoy/templates/api-deployment.yaml
+++ b/charts/galoy/templates/api-deployment.yaml
@@ -142,6 +142,11 @@ spec:
         - name: MATTERMOST_WEBHOOK_URL
           value: {{ .Values.galoy.mattermostWebhookUrl | quote }}
 
+        - name: GCP_IAM_SERVICE_ACCOUNT_PATH
+          value: "/tmp/gcp-iam-service-account/service-account.json"
+        - name: GCP_PROJECT_ID
+          value: {{ .Values.galoy.api.gcp.projectId | quote }}
+
         {{ if .Values.galoy.api.unsecureDefaultLoginCode.enabled }}
         - name: UNSECURE_DEFAULT_LOGIN_CODE
           valueFrom:
@@ -176,6 +181,9 @@ spec:
         {{ end }}
 
         volumeMounts:
+        - name: gcp-iam-service-account
+          mountPath: /tmp/gcp-iam-service-account
+          readOnly: true
         {{ if .Values.galoy.api.firebaseNotifications.enabled }}
         - name: firebase-notifications-service-account
           mountPath: /tmp/firebase-service-account/
@@ -197,3 +205,9 @@ spec:
       - name: custom-yaml
         secret:
           secretName: "{{ template "galoy.config.name" . }}"
+      - name: gcp-iam-service-account
+        secret:
+          secretName: {{ .Values.galoy.api.gcp.iamServiceAccountSecret.name }}
+          items:
+          - key: {{ .Values.galoy.api.gcp.iamServiceAccountSecret.key }}
+            path: service-account.json

--- a/charts/galoy/templates/galoy-secrets.yaml
+++ b/charts/galoy/templates/galoy-secrets.yaml
@@ -282,4 +282,20 @@ type: Opaque
 data:
   {{ .Values.galoy.telegramExistingSecret.private_key }}: {{ .Values.secrets.telegramPrivateKey | toString | b64enc }}
   {{ .Values.galoy.telegramExistingSecret.api_token_key }}: {{ .Values.secrets.telegramApiToken | toString | b64enc }}
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.galoy.api.gcp.iamServiceAccountSecret.name }}
+  labels:
+    app: {{ template "galoy.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+type: Opaque
+data:
+  {{ .Values.galoy.api.gcp.iamServiceAccountSecret.key }}: {{ .Values.secrets.gcpIamServiceAccountJson | toString | b64enc }}
+---
+
+
 {{- end -}}

--- a/charts/galoy/values.yaml
+++ b/charts/galoy/values.yaml
@@ -124,6 +124,13 @@ galoy:
     serviceType: ClusterIP
     ## Resource configuration
     resources: {}
+    ## GCP Configuration for role checking
+    ##
+    gcp:
+      projectId: ""
+      iamServiceAccountSecret:
+        name: gcp-iam-service-account
+        key: service-account-json
     ## Ingress configuration.
     ## Ref: https://kubernetes.io/docs/user-guide/ingress/
     ##
@@ -727,6 +734,8 @@ secrets:
   openaiApiKey:
   ## Pinecone api key
   pineconeApiKey:
+  ## GCP IAM service account JSON for role checking
+  gcpIamServiceAccountJson:
 ## Tracing details
 ##
 tracing:


### PR DESCRIPTION
This is:
* Provisioning a env-var called `GCP_IAM_SERVICE_ACCOUNT_PATH` with the default value of `/tmp/gcp-iam-service-account/service-account.json`
* Provisions an env-var called `GCP_PROJECT_ID` which represents the google-project, where the service-account has access

see also: https://github.com/blinkbitcoin/blink/pull/158