### PR TITLE
chore(deps): bump-lnd-backup-image-5aec38a

### DIFF
--- a/charts/lnd/values.yaml
+++ b/charts/lnd/values.yaml
@@ -12,6 +12,8 @@ backupImage:
   repository: lnd-backup
   tag: latest
   pullPolicy: IfNotPresent
+  digest: sha256:5d9f6da7db83976a5e8f10ad9d7cf6754dbaea1d50ec9773549e30a386eef749
+  git_ref: 5aec38a
 kubemonkey:
   enabled: false
 configmap:
@@ -102,7 +104,6 @@ autoGenerateTls:
 backup:
   # Enable the backup sidecar container
   enabled: false
-
   ## Google Cloud Storage backup
   ## Requires a GCS service account with bucket write permissions
   ## Create secret: kubectl create secret generic lnd-backup-gcs-sa --from-file=service-account.json=/path/to/sa.json
@@ -114,7 +115,6 @@ backup:
     serviceAccountSecret:
       name: "lnd-backup-gcs-sa"
       key: "service-account.json"
-
   ## AWS S3 backup
   ## Requires AWS credentials with S3 write permissions
   ## Create secret: kubectl create secret generic lnd-backup-aws-creds --from-literal=access-key-id=XXX --from-literal=secret-access-key=YYY
@@ -132,7 +132,6 @@ backup:
     secretKeySecret:
       name: "lnd-backup-aws-creds"
       key: "secret-access-key"
-
   ## Nextcloud/WebDAV backup
   ## Requires Nextcloud instance with WebDAV access
   ## Create secret: kubectl create secret generic lnd-backup-nextcloud --from-literal=username=XXX --from-literal=password=YYY


### PR DESCRIPTION
# Bump lnd-backup image

The lnd-backup image will be bumped to digest:
```
sha256:5d9f6da7db83976a5e8f10ad9d7cf6754dbaea1d50ec9773549e30a386eef749
```

Code diff contained in this image:

https://github.com/blinkbitcoin/charts/compare/null...5aec38a
