### PR TITLE
feat: passthrough USER_ROLE_MAP for admin-panel

### DIFF
--- a/charts/admin-panel/templates/deployment.yaml
+++ b/charts/admin-panel/templates/deployment.yaml
@@ -51,6 +51,8 @@ spec:
               key: next-auth-secret
         - name: AUTHORIZED_EMAILS
           value: {{ .Values.adminPanel.authorizedEmails }}
+        - name: USER_ROLE_MAP
+          value: {{ .Values.adminPanel.userRoleMap | toJson }}
         - name: NEXTAUTH_URL
           value: {{ .Values.adminPanel.nextAuthUrl }}
         - name: ADMIN_CORE_API

--- a/charts/admin-panel/values.yaml
+++ b/charts/admin-panel/values.yaml
@@ -11,6 +11,7 @@ adminPanel:
   adminCoreApi: http://admin-api.galoy-dev-galoy.svc.cluster.local:4001/admin/graphql
   nextAuthUrl: http://localhost:3000
   authorizedEmails: "satoshi@blink.sv,nakamoto@blink.sv"
+  userRoleMap: {}
 resources: {}
 secrets:
   create: true


### PR DESCRIPTION
Enables a env-var called USER_ROLE_MAP which passes a json-map which is mapping users to roles from a chart param to a env-var for the admin-panel. 