### PR TITLE
fix(lndmon): extend lnd.host address

### DIFF
--- a/charts/lnd/charts/lndmon/templates/statefulset.yaml
+++ b/charts/lnd/charts/lndmon/templates/statefulset.yaml
@@ -76,7 +76,7 @@ spec:
         args:
         - --prometheus.listenaddr=0.0.0.0:{{ .Values.service.port }}
         - --lnd.network={{ .Values.global.network }}
-        - --lnd.host={{ .Values.lnd.serviceName | default .Release.Name }}:{{ .Values.lnd.rpcPort }}
+        - --lnd.host={{ .Values.lnd.serviceName | default .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.lnd.rpcPort }}
         - --lnd.macaroondir=/lnd-data/data/chain/bitcoin/{{ .Values.global.network }}
         - --lnd.tlspath=/lnd-data/tls.cert
         {{- range .Values.extraArgs }}


### PR DESCRIPTION
Simple fix on the chart level to change the lnd.host address to one on which the tls.cert is valid.