### PR TITLE
fix: replace bitnami repo with bitnamilegacy

### DIFF
--- a/charts/galoy/values.yaml
+++ b/charts/galoy/values.yaml
@@ -2,7 +2,9 @@
 ## This is a YAML-formatted file.
 ## Declare variables to be passed into your templates.
 
-# necessary to allow repository changes for mongodb and redis
+# necessary to allow repository changes for mongodb and redis (see below) because
+# https://github.com/bitnami/containers/issues/83267
+# ToDo: switch to non-bitnami-charts
 global:
   security:
     allowInsecureImages: true

--- a/charts/galoy/values.yaml
+++ b/charts/galoy/values.yaml
@@ -8,6 +8,13 @@ nameOverride:
 ## Provide a name to substitute for the full names of resources
 ##
 fullnameOverride:
+
+# necessary to change redis and mongodb repo sources in order to have a temp solution for:
+# https://github.com/bitnami/containers/issues/83267
+global:
+  security:
+    allowInsecureImages: true
+
 galoy:
   ## Bitcoin Network to run this Galoy instance on
   ##
@@ -599,9 +606,6 @@ galoy:
 # Therefore it doesn't have any enable/disable flag.
 #
 mongodb:
-  # necessary to allow repository changes for mongodb
-  security:
-    allowInsecureImages: true
   image:
     repository: bitnamilegacy/mongodb
   # Authentication Configuration
@@ -653,9 +657,6 @@ mongodb:
 ## Therefore it doesn't have any enable/disable flag.
 ##
 redis:
-  # necessary to allow repository changes for redis
-  security:
-  allowInsecureImages: true
   image:
     repository: bitnamilegacy/redis
   ## Redis replica config params

--- a/charts/galoy/values.yaml
+++ b/charts/galoy/values.yaml
@@ -599,6 +599,8 @@ galoy:
 # Therefore it doesn't have any enable/disable flag.
 #
 mongodb:
+  image:
+    repository: bitnamilegacy/mongodb
   # Authentication Configuration
   auth:
     # Existing secret for authentication
@@ -648,6 +650,8 @@ mongodb:
 ## Therefore it doesn't have any enable/disable flag.
 ##
 redis:
+  image:
+    repository: bitnamilegacy/redis
   ## Redis replica config params
   replica:
     # Number of Redis to deploy
@@ -748,6 +752,8 @@ price:
     host: galoy-price-history
     port: 50052
 postgresql:
+  image:
+    repository: bitnamilegacy/postgresql
   enabled: true
   auth:
     enablePostgresUser: false

--- a/charts/galoy/values.yaml
+++ b/charts/galoy/values.yaml
@@ -2,13 +2,6 @@
 ## This is a YAML-formatted file.
 ## Declare variables to be passed into your templates.
 
-# necessary to allow repository changes for mongodb and redis (see below) because
-# https://github.com/bitnami/containers/issues/83267
-# ToDo: switch to non-bitnami-charts
-global:
-  security:
-    allowInsecureImages: true
-
 ## Provide a name in place of `galoy` for `app:` labels
 ##
 nameOverride:
@@ -606,6 +599,10 @@ galoy:
 # Therefore it doesn't have any enable/disable flag.
 #
 mongodb:
+  # necessary to allow repository changes for mongodb
+  global:
+    security:
+      allowInsecureImages: true
   image:
     repository: bitnamilegacy/mongodb
   # Authentication Configuration
@@ -657,6 +654,10 @@ mongodb:
 ## Therefore it doesn't have any enable/disable flag.
 ##
 redis:
+  # necessary to allow repository changes for redis
+  global:
+    security:
+      allowInsecureImages: true
   image:
     repository: bitnamilegacy/redis
   ## Redis replica config params

--- a/charts/galoy/values.yaml
+++ b/charts/galoy/values.yaml
@@ -600,9 +600,8 @@ galoy:
 #
 mongodb:
   # necessary to allow repository changes for mongodb
-  global:
-    security:
-      allowInsecureImages: true
+  security:
+    allowInsecureImages: true
   image:
     repository: bitnamilegacy/mongodb
   # Authentication Configuration
@@ -655,9 +654,8 @@ mongodb:
 ##
 redis:
   # necessary to allow repository changes for redis
-  global:
-    security:
-      allowInsecureImages: true
+  security:
+  allowInsecureImages: true
   image:
     repository: bitnamilegacy/redis
   ## Redis replica config params

--- a/charts/galoy/values.yaml
+++ b/charts/galoy/values.yaml
@@ -2,6 +2,11 @@
 ## This is a YAML-formatted file.
 ## Declare variables to be passed into your templates.
 
+# necessary to allow repository changes for mongodb and redis
+global:
+  security:
+    allowInsecureImages: true
+
 ## Provide a name in place of `galoy` for `app:` labels
 ##
 nameOverride:
@@ -667,6 +672,8 @@ redis:
   ## Use sentinel on Redis pods
   sentinel:
     enabled: true
+    image:
+      repository: bitnamilegacy/redis-sentinel
     ## Master set name
     masterSet: mymaster
   ## Sidecar prometheus exporter

--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -1,10 +1,10 @@
 include('./galoy-deps/Tiltfile')
 include('./bitcoin/Tiltfile')
-#include('./monitoring/Tiltfile')
+include('./monitoring/Tiltfile')
 include('./galoy/Tiltfile')
 include('./addons/Tiltfile')
-#include('./stablesats/Tiltfile')
-#include('./kafka-connect/Tiltfile')
+include('./stablesats/Tiltfile')
+include('./kafka-connect/Tiltfile')
 include('./smoketest/Tiltfile')
 
 watch_settings(ignore=['**/charts/*.tgz', '**/tmpcharts-*'])

--- a/dev/Tiltfile
+++ b/dev/Tiltfile
@@ -1,8 +1,10 @@
 include('./galoy-deps/Tiltfile')
 include('./bitcoin/Tiltfile')
-include('./monitoring/Tiltfile')
+#include('./monitoring/Tiltfile')
 include('./galoy/Tiltfile')
 include('./addons/Tiltfile')
-include('./stablesats/Tiltfile')
-include('./kafka-connect/Tiltfile')
+#include('./stablesats/Tiltfile')
+#include('./kafka-connect/Tiltfile')
 include('./smoketest/Tiltfile')
+
+watch_settings(ignore=['**/charts/*.tgz', '**/tmpcharts-*'])

--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,7 @@
               yq-go
               kubernetes-helm
               opentofu
+              k9s
             ];
 
             shellHook = ''


### PR DESCRIPTION
We need to switch out the bitnami charts but in the meantime, let's temporally use bitnamylegacy images.
https://github.com/bitnami/containers/issues/83267

Also:
* Adding [k9s](https://k9scli.io/) to the nix available binaries. Quite usefull for dev
* For me, Tilt went in a endless loop because after downloading the chart dependencies. The change in the Tiltfile prevents that by ignoring the directories where helm is downloading dependent charts.