### PR TITLE
fix: use bitnamilegacy repo for postgresql images

### DIFF
--- a/charts/bria/values.yaml
+++ b/charts/bria/values.yaml
@@ -1,3 +1,9 @@
+# needed to use the bitnamilegacy repository
+# https://github.com/bitnami/containers/issues/83267
+global:
+  security:
+    allowInsecureImages: true
+
 fullnameOverride: ""
 nameOverride: ""
 bria:
@@ -47,6 +53,8 @@ bria:
     signerEncryptionKey: ""
     annotations:
 postgresql:
+  image:
+    repository: bitnamilegacy/postgresql
   enabled: true
   auth:
     enablePostgresUser: false

--- a/charts/lnd/values.yaml
+++ b/charts/lnd/values.yaml
@@ -1,5 +1,9 @@
 global:
   network: mainnet
+  # needed to use the bitnamilegacy repository
+  # https://github.com/bitnami/containers/issues/83267
+  security:
+    allowInsecureImages: true
 image:
   repository: lightninglabs/lnd
   tag: v0.18.5-beta
@@ -111,6 +115,8 @@ lnd:
         maxconnections: 21
 # PostgreSQL configuration
 postgresql:
+  image:
+    repository: bitnamilegacy/postgresql
   enabled: false # Set to true to deploy PostgreSQL
   auth:
     enablePostgresUser: false

--- a/charts/stablesats/values.yaml
+++ b/charts/stablesats/values.yaml
@@ -1,3 +1,8 @@
+# needed to use the bitnamilegacy repository
+# https://github.com/bitnami/containers/issues/83267
+global:
+  security:
+    allowInsecureImages: true
 secrets:
   create: true
   pgCon: ""
@@ -58,6 +63,8 @@ stablesats:
     payoutQueueName: "dev-queue"
     onchainAddressExternalId: "dev-onchain-address"
 postgresql:
+  image:
+    repository: bitnamilegacy/postgresql
   enabled: true
   auth:
     enablePostgresUser: false

--- a/charts/voucher/values.yaml
+++ b/charts/voucher/values.yaml
@@ -1,3 +1,8 @@
+# needed to use the bitnamilegacy repository
+# https://github.com/bitnami/containers/issues/83267
+global:
+  security:
+    allowInsecureImages: true
 secrets:
   create: true
   nextAuthSecret: ""
@@ -22,6 +27,8 @@ service:
   port: 3000
   type: ClusterIP
 postgresql:
+  image:
+    repository: bitnamilegacy/postgresql
   enabled: true
   auth:
     enablePostgresUser: false


### PR DESCRIPTION
Follow up of: https://github.com/blinkbitcoin/charts/pull/8258
changing all bitnami images to use the bitnamilegacey repo.