### PR TITLE
fix(ci): use bitnamilegacy/postgresql images in testflight, match versions

### DIFF
--- a/ci/testflight/galoy-auth/postgres-testflight-values.yml.tmpl
+++ b/ci/testflight/galoy-auth/postgres-testflight-values.yml.tmpl
@@ -1,3 +1,6 @@
+image:
+  repository: bitnamilegacy/postgresql
+
 auth:
   postgresPassword: ${postgres_password}
   database: ${postgres_database}

--- a/ci/testflight/galoy/api-keys-postgresql-values.yml
+++ b/ci/testflight/galoy/api-keys-postgresql-values.yml
@@ -1,6 +1,9 @@
 # Settings from:
 # https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml
 
+image:
+  repository: bitnamilegacy/postgresql
+
 auth:
   username: api-keys
   password: api-keys

--- a/ci/testflight/galoy/main.tf
+++ b/ci/testflight/galoy/main.tf
@@ -363,7 +363,7 @@ resource "helm_release" "postgresql" {
   name       = "postgresql"
   repository = "https://charts.bitnami.com/bitnami"
   chart      = "postgresql"
-  version    = "11.9.13"
+  version    = "16.4.16"
   namespace  = kubernetes_namespace.testflight.metadata[0].name
 
   values = [
@@ -375,7 +375,7 @@ resource "helm_release" "api_keys_postgresql" {
   name       = "api-keys-postgresql"
   repository = "https://charts.bitnami.com/bitnami"
   chart      = "postgresql"
-  version    = "11.9.13"
+  version    = "16.4.16"
   namespace  = kubernetes_namespace.testflight.metadata[0].name
 
   values = [
@@ -387,7 +387,7 @@ resource "helm_release" "notifications_postgresql" {
   name       = "notifications-postgresql"
   repository = "https://charts.bitnami.com/bitnami"
   chart      = "postgresql"
-  version    = "11.9.13"
+  version    = "16.4.16"
   namespace  = kubernetes_namespace.testflight.metadata[0].name
 
   values = [

--- a/ci/testflight/galoy/notifications-postgresql-values.yml
+++ b/ci/testflight/galoy/notifications-postgresql-values.yml
@@ -1,6 +1,9 @@
 # Settings from:
 # https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml
 
+image:
+  repository: bitnamilegacy/postgresql
+
 auth:
   username: notifications
   password: notifications

--- a/ci/testflight/galoy/postgresql-values.yml
+++ b/ci/testflight/galoy/postgresql-values.yml
@@ -1,6 +1,9 @@
 # Settings from:
 # https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml
 
+image:
+  repository: bitnamilegacy/postgresql
+
 auth:
   username: kratos-pg
   password: kratos-pg

--- a/ci/testflight/galoy/testflight-values.yml
+++ b/ci/testflight/galoy/testflight-values.yml
@@ -29,6 +29,8 @@ galoy:
 
 price:
   postgresql:
+    image:
+      repository: bitnamilegacy/postgresql
     primary:
       persistence:
         enabled: false


### PR DESCRIPTION
to fix the error in the galoy testflight:
```
ormal   Scheduled  4m10s                default-scheduler  Successfully assigned galoy-testflight-a496c63/api-keys-postgresql-0 to gke-galoy-staging-cl-galoy-staging-n2-49e7cdb5-b7p7
  Normal   Pulling    80s (x5 over 4m10s)  kubelet            Pulling image "docker.io/bitnami/postgresql:14.5.0-debian-11-r35"
  Warning  Failed     79s (x5 over 4m10s)  kubelet            Failed to pull image "docker.io/bitnami/postgresql:14.5.0-debian-11-r35": rpc error: code = NotFound desc = failed to pull and unpack image "docker.io/bitnami/postgresql:14.5.0-debian-11-r35": failed to resolve reference "docker.io/bitnami/postgresql:14.5.0-debian-11-r35": docker.io/bitnami/postgresql:14.5.0-debian-11-r35: not found
  Warning  Failed     79s (x5 over 4m10s)  kubelet            Error: ErrImagePull
  Warning  Failed     18s (x15 over 4m9s)  kubelet            Error: ImagePullBackOff
  Normal   BackOff    4s (x16 over 4m9s)   kubelet            Back-off pulling image "docker.io/bitnami/postgresql:14.5.0-debian-11-r35"
```