### PR TITLE
fix(ci): use the latest bitnami chart version in testflight

### DIFF
--- a/ci/testflight/galoy/main.tf
+++ b/ci/testflight/galoy/main.tf
@@ -363,7 +363,6 @@ resource "helm_release" "postgresql" {
   name       = "postgresql"
   repository = "https://charts.bitnami.com/bitnami"
   chart      = "postgresql"
-  version    = "16.4.16"
   namespace  = kubernetes_namespace.testflight.metadata[0].name
 
   values = [
@@ -375,7 +374,6 @@ resource "helm_release" "api_keys_postgresql" {
   name       = "api-keys-postgresql"
   repository = "https://charts.bitnami.com/bitnami"
   chart      = "postgresql"
-  version    = "16.4.16"
   namespace  = kubernetes_namespace.testflight.metadata[0].name
 
   values = [
@@ -387,7 +385,6 @@ resource "helm_release" "notifications_postgresql" {
   name       = "notifications-postgresql"
   repository = "https://charts.bitnami.com/bitnami"
   chart      = "postgresql"
-  version    = "16.4.16"
   namespace  = kubernetes_namespace.testflight.metadata[0].name
 
   values = [


### PR DESCRIPTION
Removing the pinned version makes terraform use the latest version.