### PR TITLE
fix(ci): use oci registry-1.docker.io bitnamicharts

### DIFF
--- a/ci/testflight/galoy/main.tf
+++ b/ci/testflight/galoy/main.tf
@@ -361,7 +361,7 @@ resource "kubernetes_secret" "notifications" {
 
 resource "helm_release" "postgresql" {
   name       = "postgresql"
-  repository = "https://charts.bitnami.com/bitnami"
+  repository = "oci://registry-1.docker.io/bitnamicharts"
   chart      = "postgresql"
   namespace  = kubernetes_namespace.testflight.metadata[0].name
 
@@ -372,7 +372,7 @@ resource "helm_release" "postgresql" {
 
 resource "helm_release" "api_keys_postgresql" {
   name       = "api-keys-postgresql"
-  repository = "https://charts.bitnami.com/bitnami"
+  repository = "oci://registry-1.docker.io/bitnamicharts"
   chart      = "postgresql"
   namespace  = kubernetes_namespace.testflight.metadata[0].name
 
@@ -383,7 +383,7 @@ resource "helm_release" "api_keys_postgresql" {
 
 resource "helm_release" "notifications_postgresql" {
   name       = "notifications-postgresql"
-  repository = "https://charts.bitnami.com/bitnami"
+  repository = "oci://registry-1.docker.io/bitnamicharts"
   chart      = "postgresql"
   namespace  = kubernetes_namespace.testflight.metadata[0].name
 


### PR DESCRIPTION
Recommended in: https://artifacthub.io/packages/helm/bitnami/postgresql

To fix in testflight:
```
│ Error: could not download chart: invalid_reference: invalid tag

│ 

│   with helm_release.postgresql,

│   on main.tf line 362, in resource "helm_release" "postgresql":

│  362: resource "helm_release" "postgresql" {
```