### PR TITLE
feat(galoy): add BTC Map deployment config

### DIFF
--- a/charts/galoy/Chart.yaml
+++ b/charts/galoy/Chart.yaml
@@ -12,7 +12,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.34.7-dev
+version: 0.34.8-dev
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/galoy/templates/api-deployment.yaml
+++ b/charts/galoy/templates/api-deployment.yaml
@@ -86,6 +86,21 @@ spec:
               name: {{ .Values.galoy.proxyCheckExistingSecret.name }}
               key: {{ .Values.galoy.proxyCheckExistingSecret.key }}
 
+        {{ if .Values.galoy.btcMap.enabled }}
+        - name: BTCMAP_API_URL
+          value: {{ .Values.galoy.btcMap.apiUrl | quote }}
+        - name: BTCMAP_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.galoy.btcMap.existingSecret.name }}
+              key: {{ .Values.galoy.btcMap.existingSecret.tokenKey }}
+        - name: BTCMAP_HMAC_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.galoy.btcMap.existingSecret.name }}
+              key: {{ .Values.galoy.btcMap.existingSecret.hmacSecretKey }}
+        {{ end }}
+
         - name: LND_PRIORITY
           value: {{ .Values.galoy.lndPriority }}
 {{/* Databases */}}

--- a/charts/galoy/templates/required-checks.yaml
+++ b/charts/galoy/templates/required-checks.yaml
@@ -1,3 +1,9 @@
 {{ if or (not (eq (len .Values.mongodb.auth.databases) 1)) (not (eq (len .Values.mongodb.auth.usernames) 1)) }}
 {{- required "There should be only one username/database for Galoy" "" -}}
 {{ end }}
+{{- if .Values.galoy.btcMap.enabled }}
+{{- $_ := required "galoy.btcMap.apiUrl is required when BTC Map is enabled" .Values.galoy.btcMap.apiUrl }}
+{{- $_ := required "galoy.btcMap.existingSecret.name is required when BTC Map is enabled" .Values.galoy.btcMap.existingSecret.name }}
+{{- $_ := required "galoy.btcMap.existingSecret.tokenKey is required when BTC Map is enabled" .Values.galoy.btcMap.existingSecret.tokenKey }}
+{{- $_ := required "galoy.btcMap.existingSecret.hmacSecretKey is required when BTC Map is enabled" .Values.galoy.btcMap.existingSecret.hmacSecretKey }}
+{{- end }}

--- a/charts/galoy/values.yaml
+++ b/charts/galoy/values.yaml
@@ -24,6 +24,15 @@ galoy:
     port: 80
   # LND used as primary lightning node, can be either lnd1 or lnd2
   lndPriority: lnd1
+  ## BTC Map place submission integration.
+  ## Credentials must be supplied through an existing Kubernetes Secret.
+  btcMap:
+    enabled: false
+    apiUrl: ""
+    existingSecret:
+      name: ""
+      tokenKey: api-token
+      hmacSecretKey: hmac-secret
   config:
     paymentNetworks:
       onchain:

--- a/ci/testflight/galoy/main.tf
+++ b/ci/testflight/galoy/main.tf
@@ -325,6 +325,17 @@ resource "kubernetes_secret" "proxy_check_api_key" {
   }
 }
 
+resource "kubernetes_secret" "btcmap" {
+  metadata {
+    name      = "btcmap-api-credentials"
+    namespace = kubernetes_namespace.testflight.metadata[0].name
+  }
+  data = {
+    "api-token"   = "dummy"
+    "hmac-secret" = "stable-testflight-hmac-secret"
+  }
+}
+
 # open ai api key
 resource "kubernetes_secret" "openai_api_key" {
   metadata {
@@ -426,6 +437,7 @@ resource "helm_release" "galoy" {
     kubernetes_secret.lnd2_credentials,
     kubernetes_secret.lnd2_pubkey,
     kubernetes_secret.price_history_postgres_creds,
+    kubernetes_secret.btcmap,
     helm_release.postgresql
   ]
 

--- a/ci/testflight/galoy/testflight-values.yml
+++ b/ci/testflight/galoy/testflight-values.yml
@@ -1,6 +1,14 @@
 galoy:
   network: signet
 
+  btcMap:
+    enabled: true
+    apiUrl: https://btcmap.invalid/rpc
+    existingSecret:
+      name: btcmap-api-credentials
+      tokenKey: api-token
+      hmacSecretKey: hmac-secret
+
   trigger:
     backups:
       gcs:


### PR DESCRIPTION
## Summary

- add disabled-by-default `galoy.btcMap` chart configuration
- inject the API URL and existing-secret references only when enabled
- fail rendering when enabled configuration is incomplete
- cover enabled and disabled rendering in testflight configuration

## Validation

- `helm lint charts/galoy`
- default disabled `helm template`
- enabled testflight `helm template`

Part of blinkbitcoin/blink-wip#1184.
