### PR TITLE
chore-bump-blink-terminal-image-66dab33

### DIFF
--- a/charts/blink-terminal/Chart.yaml
+++ b/charts/blink-terminal/Chart.yaml
@@ -3,7 +3,7 @@ name: blink-terminal
 description: A Helm chart for the blink-terminal (BlinkPOS) merchant terminal
 type: application
 version: 0.1.0-dev
-appVersion: 0.8.0
+appVersion: 0.8.1
 dependencies:
   - name: postgresql
     version: 18.5.2

--- a/charts/blink-terminal/values.yaml
+++ b/charts/blink-terminal/values.yaml
@@ -25,7 +25,7 @@ blinkTerminal:
   citrusrateBaseUrl: "https://citrusrate-be.onrender.com"
 image:
   repository: us.gcr.io/galoy-org/blink-terminal
-  digest: "sha256:8f1a612f3b386a5e0d572796c43b0b9e93f7db4f951bd4dce5a036201587c48b" # METADATA:: repository=https://github.com/blinkbitcoin/blink-terminal;commit_ref=e3884cf;app=blink-terminal;
+  digest: "sha256:bcbe7e5ff9018a1d200d6d82e27eceea3547c356b406da545235f5130a8bce55" # METADATA:: repository=https://github.com/blinkbitcoin/blink-terminal;commit_ref=66dab33;app=blink-terminal;
 psqlImage: "postgres:15"
 ingress:
   enabled: false


### PR DESCRIPTION
# Bump blink-terminal image

The blink-terminal image will be bumped to digest:


Code diff contained in this image:

https://github.com/blinkbitcoin/blink-terminal/compare/e3884cf...66dab33
