### PR TITLE
fix(testflight): order app secrets after the namespace that holds them

### DIFF
--- a/ci/testflight/admin-panel/main.tf
+++ b/ci/testflight/admin-panel/main.tf
@@ -29,7 +29,7 @@ resource "kubernetes_secret" "smoketest" {
 resource "kubernetes_secret" "admin_panel" {
   metadata {
     name      = "admin-panel"
-    namespace = local.testflight_namespace
+    namespace = kubernetes_namespace.testflight.metadata[0].name
   }
 
   data = {

--- a/ci/testflight/api-dashboard/main.tf
+++ b/ci/testflight/api-dashboard/main.tf
@@ -29,7 +29,7 @@ resource "kubernetes_secret" "smoketest" {
 resource "kubernetes_secret" "api_dashboard" {
   metadata {
     name      = "api-dashboard"
-    namespace = local.testflight_namespace
+    namespace = kubernetes_namespace.testflight.metadata[0].name
   }
 
   data = {

--- a/ci/testflight/blink-terminal/main.tf
+++ b/ci/testflight/blink-terminal/main.tf
@@ -44,7 +44,7 @@ resource "random_password" "encryption_key" {
 resource "kubernetes_secret" "blink_terminal" {
   metadata {
     name      = "blink-terminal"
-    namespace = local.testflight_namespace
+    namespace = kubernetes_namespace.testflight.metadata[0].name
   }
 
   data = {

--- a/ci/testflight/galoy-auth/main.tf
+++ b/ci/testflight/galoy-auth/main.tf
@@ -34,7 +34,7 @@ resource "kubernetes_secret" "smoketest" {
 resource "kubernetes_secret" "auth_backend" {
   metadata {
     name      = "auth-backend"
-    namespace = local.testflight_namespace
+    namespace = kubernetes_namespace.testflight.metadata[0].name
   }
   data = {
     "session-keys" : local.session_keys

--- a/ci/testflight/galoy-pay/main.tf
+++ b/ci/testflight/galoy-pay/main.tf
@@ -42,7 +42,7 @@ resource "helm_release" "galoy_pay" {
 resource "kubernetes_secret" "galoy_pay" {
   metadata {
     name      = "galoy-pay"
-    namespace = local.testflight_namespace
+    namespace = kubernetes_namespace.testflight.metadata[0].name
   }
 
   data = {

--- a/ci/testflight/map/main.tf
+++ b/ci/testflight/map/main.tf
@@ -29,7 +29,7 @@ resource "kubernetes_secret" "smoketest" {
 resource "kubernetes_secret" "map" {
   metadata {
     name      = "map"
-    namespace = local.testflight_namespace
+    namespace = kubernetes_namespace.testflight.metadata[0].name
   }
 
   data = {

--- a/ci/testflight/voucher/main.tf
+++ b/ci/testflight/voucher/main.tf
@@ -34,7 +34,7 @@ resource "random_password" "postgresql" {
 resource "kubernetes_secret" "voucher" {
   metadata {
     name      = "voucher"
-    namespace = local.testflight_namespace
+    namespace = kubernetes_namespace.testflight.metadata[0].name
   }
 
   data = {


### PR DESCRIPTION
## What broke

`blink-terminal-testflight` [#36](https://ci.blink.sv/teams/dev/pipelines/helm-charts/jobs/blink-terminal-testflight/builds/36) failed:

```
Error: namespaces "blink-terminal-testflight-571f133" not found
  with kubernetes_secret.blink_terminal,
  on main.tf line 44, in resource "kubernetes_secret" "blink_terminal":
```

## Why

The build log has the answer in its timestamps:

```
18:45:39  kubernetes_namespace.testflight: Creating...
18:45:39  kubernetes_secret.blink_terminal: Creating...        <-- same second, in parallel
18:45:39  kubernetes_namespace.testflight: Creation complete after 1s
```

The secret took its namespace from `local.testflight_namespace` — a plain string — instead of from the namespace resource. A string carries no dependency, so Terraform saw no edge between the two and scheduled them **concurrently**. The namespace normally wins by a few milliseconds, which is why 35 earlier builds were green. #36 is simply the first time it lost.

This is a latent race, not a regression: the file is unchanged since the chart was added in f4090a74. The `helm_release` already declares `depends_on = [kubernetes_secret.blink_terminal]`, so the ordering was half expressed — it was just one hop short.

## The fix

```diff
 resource "kubernetes_secret" "blink_terminal" {
   metadata {
     name      = "blink-terminal"
-    namespace = local.testflight_namespace
+    namespace = kubernetes_namespace.testflight.metadata[0].name
   }
```

Referencing the attribute restores the implicit dependency. `tofu graph` before vs after, which is the actual proof:

```diff
- kubernetes_secret.blink_terminal -> local.testflight_namespace      (a value; no ordering)
+ kubernetes_secret.blink_terminal -> kubernetes_namespace.testflight (a real edge)
```

It fixes **destroy** ordering too, which matters here because every testflight job ends with `put: ... action: destroy` — the secret is now torn down before its namespace.

## Why seven charts

Six siblings were copied from the same template and carry the identical race: `admin-panel`, `api-dashboard`, `map`, `voucher`, `galoy-pay`, `galoy-auth`. Fixing them together beats waiting for each to fail on its own schedule. The larger charts (`galoy`, `lnd`, `bria`, `stablesats`, `bitcoind`, `specter`, `mempool`, `fulcrum`, ...) already used the resource reference and are untouched.

**Deliberately unchanged:** every remaining `namespace = local.*` points at a namespace this configuration does not create — `smoketest`, `galoy`, `bitcoin`, `kafka`. Those have nothing to depend on, and adding an edge there would be wrong. I swept all 20 testflight configs to confirm no other instance of this bug remains.

## Verification

`tofu validate` and `tofu graph` on all seven configurations: each valid, each now carrying the `secret -> namespace` edge. `tofu fmt -check` clean. (Only the pre-existing `kubernetes_namespace` → `kubernetes_namespace_v1` deprecation warnings remain, unrelated and already present in the CI log.)

Re-running #36 would very likely go green on its own — the race usually resolves the right way — so this is about removing the flake permanently rather than unblocking a hard failure.

## Note

#36 died before the pipeline's `destroy` step, so namespace `blink-terminal-testflight-571f133` and its TF state may be orphaned in `galoy-staging`. Someone with cluster access may need a one-time cleanup if the next run reports the namespace already exists.
